### PR TITLE
add nuget restore

### DIFF
--- a/.github/workflows/component-detection.yml
+++ b/.github/workflows/component-detection.yml
@@ -10,8 +10,9 @@ permissions:
 
 jobs:
   dependency-submission:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
+      - run: nuget restore .\Fsharp-WebAPI.sln
       - name: Component detection 
         uses: advanced-security/component-detection-dependency-submission-action@v0.0.2


### PR DESCRIPTION
This pull request for `.github/workflows/component-detection.yml` involves a change in the operating system for the job `dependency-submission` from `ubuntu-latest` to `windows-latest`, and the addition of a new step to restore NuGet packages for the `Fsharp-WebAPI.sln` solution.

Changes to the GitHub Actions workflow:

* <a href="diffhunk://#diff-34e1e8ddf70ef83920629e3f07470e673ba2359b72bf60aaac70e6f139ad398eL13-R16">`.github/workflows/component-detection.yml`</a>: The job `dependency-submission` now runs on `windows-latest` instead of `ubuntu-latest`. Additionally, a new step to run `nuget restore .\Fsharp-WebAPI.sln` has been added before the component detection step.