### PR TITLE
add fsharp.data nuget reference

### DIFF
--- a/Fsharp-WebAPI.fsproj
+++ b/Fsharp-WebAPI.fsproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FSharp.Data" Version="6.3.0" />
     <PackageReference Include="FSharpLint" Version="0.2.8" />
   </ItemGroup>
 


### PR DESCRIPTION
This pull request to `Fsharp-WebAPI.fsproj` includes a change to add a new package reference. The most important change is the addition of the `FSharp.Data` package, which is a library for working with structured file formats (like CSV, HTML, JSON, and XML) and for accessing the WorldBank data.

Package reference addition:

* <a href="diffhunk://#diff-b20cdb0544227d64a965533163eac46ac56f5e1457d0711543201cb8f3f0df7dR15">`Fsharp-WebAPI.fsproj`</a>: Added a new package reference, `FSharp.Data` version `6.3.0`, which is a useful library for data manipulation tasks in F#.